### PR TITLE
Minor improvements for publishing

### DIFF
--- a/dist/crossfilter-multigroup.js
+++ b/dist/crossfilter-multigroup.js
@@ -1,3 +1,9 @@
+/*!
+ * crossfilter-multigroup v0.5.0
+ * Copyright (c) 2015 Open Counter Enterprises, Inc.
+ * This software is free to use under the MIT license.
+ * See https://github.com/opencounter/crossfilter-multigroup/blob/master/LICENSE
+ */
 (function (global, factory) {
   if (typeof define === "function" && define.amd) {
     define(["exports", "module"], factory);

--- a/package.json
+++ b/package.json
@@ -2,12 +2,13 @@
   "name": "crossfilter-multigroup",
   "version": "0.5.0",
   "description": "A specialized Crossfilter group for handling dimensions that are lists",
-  "main": "crossfilter-multigroup.js",
+  "main": "dist/crossfilter-multigroup.js",
   "directories": {
     "test": "test"
   },
   "scripts": {
-    "build": "npm install && babel --modules umd $npm_package_main --out-file dist/$npm_package_name.js && uglifyjs --compress --preamble \"`./banner.sh`\" -- dist/$npm_package_name.js > dist/$npm_package_name.min.js",
+    "build": "echo \"`./banner.sh`\\n`babel --modules umd $npm_package_main`\" > dist/$npm_package_name.js && uglifyjs --compress --comments '/license/i' -- dist/$npm_package_name.js > dist/$npm_package_name.min.js",
+    "prepublish": "npm run build",
     "test": "mocha --compilers js:babel/register"
   },
   "keywords": [


### PR DESCRIPTION
- Update scripts so that the license banner is present on _both_ minified and non-minified versions.
- Add building as a prepublish step.
- Ensure `main` points towards the built version (for consumers who don’t have Babel support).
